### PR TITLE
Rotation about an arbitrary origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 spec/sample_output/*.pdf
 prawn-svg-*.gem
+Gemfile*
+.rvmrc

--- a/lib/prawn/svg/element.rb
+++ b/lib/prawn/svg/element.rb
@@ -56,8 +56,13 @@ class Prawn::Svg::Element
           x, y = x.split(/\s+/) if y.nil?
           add_call_and_enter name, @document.distance(x), -@document.distance(y)
 
-        when 'rotate'          
-          add_call_and_enter name, -arguments.first.to_f, :origin => [0, @document.y('0')]
+        when 'rotate'
+          rotation_arguments = arguments.first.split(/\s+/)
+          if (rotation_arguments.length == 3)
+            add_call_and_enter name, -rotation_arguments.first.to_f, :origin => [@document.x(rotation_arguments[1].to_f), @document.y(rotation_arguments[2].to_f)]
+          else
+            add_call_and_enter name, -arguments.first.to_f, :origin => [0, @document.y('0')]
+          end
 
         when 'scale'
           args = arguments.first.split(/\s+/)


### PR DESCRIPTION
hi mogest,

I ran across a bug whereby the rotation origin of the rotate transform was not being honored by prawn-svg.  I think I've added a fix to element.rb that shouldn't break backwards compatibility: if the additional x and y arguments are present they are used.  Otherwise the code falls back on the previous behavior.

I would love to write a passing test for this (and to run your suite to make sure I haven't broken anything) but I'm having some trouble getting rspec to run.  Which version of ruby & rspec should I be using -- should I simply be able to run rake?  I noticed that spec/rake/spectask doesn't exist but is required in the Rakefile.  Is that an issue?  Sorry for the noobness here, I don't have a lot of experience with configuring rspec.

Thanks!

Onsi
