### PR TITLE
Fix deprecation warnings in Ruby 1.9+

### DIFF
--- a/lib/prawn/svg/font.rb
+++ b/lib/prawn/svg/font.rb
@@ -56,8 +56,8 @@ class Prawn::Svg::Font
     
   def self.font_information(filename)
     File.open(filename, "r") do |f|
-      x = f.read(12).ord
-      table_count = x[4] * 256 + x[5]
+      x = f.read(12)
+      table_count = x[4].ord * 256 + x[5].ord
       tables = f.read(table_count * 16)
 
       offset, length = table_count.times do |index|
@@ -84,7 +84,12 @@ class Prawn::Svg::Font
         field = data[offset..offset+length-1]        
         names[name_id] = if platform_id == 0
           begin
-            field.encode(Encoding::UTF16)
+            if field.respond_to?(:encode)
+              field.encode(Encoding::UTF16)
+            else
+              require "iconv"
+              Iconv.iconv('UTF-8', 'UTF-16', field)
+            end
           rescue
             field
           end


### PR DESCRIPTION
This fixes the following deprecation warning in later Ruby 1.9 versions:

```
prawn-svg/lib/prawn/svg/font.rb:1:in `<top (required)>': iconv will be deprecated in the future, use String#encode instead.
```

Additionally, a small incompatibility with Ruby 1.9 was fixed.
