### PR TITLE
Close paths on Z/z

### DIFF
--- a/lib/prawn/svg/parser.rb
+++ b/lib/prawn/svg/parser.rb
@@ -164,11 +164,15 @@ class Prawn::Svg::Parser
     end
 
     commands.collect do |command, args|
-      point_to = [x(args[0]), y(args[1])]
-      if command == 'curve_to'
-        opts = {:bounds => [[x(args[2]), y(args[3])], [x(args[4]), y(args[5])]]}
+      if args && args.length > 0
+        point_to = [x(args[0]), y(args[1])]
+        if command == 'curve_to'
+          opts = {:bounds => [[x(args[2]), y(args[3])], [x(args[4]), y(args[5])]]}
+        end
+        element.add_call command, point_to, opts
+      else
+        element.add_call command
       end
-      element.add_call command, point_to, opts
     end  
   end
   

--- a/lib/prawn/svg/parser/path.rb
+++ b/lib/prawn/svg/parser/path.rb
@@ -68,7 +68,8 @@ module Prawn
       
         when 'Z' # closepath
           if @subpath_initial_point
-            @calls << ["line_to", @subpath_initial_point]
+            #@calls << ["line_to", @subpath_initial_point]
+            @calls << ["close_path"]
             @last_point = @subpath_initial_point
           end
     

--- a/spec/lib/path_spec.rb
+++ b/spec/lib/path_spec.rb
@@ -9,7 +9,7 @@ describe Prawn::Svg::Parser::Path do
     it "correctly parses a valid path" do
       calls = []
       @path.stub!(:run_path_command) {|*args| calls << args}
-      @path.parse("A12.34 -56.78 89B4 5   C  6,7 T QX 0")
+      @path.parse("A12.34 -56.78 89B4 5   C  6,7 T QX 0 Z")
       
       calls.should == [
         ["A", [12.34, -56.78, 89]],
@@ -17,7 +17,8 @@ describe Prawn::Svg::Parser::Path do
         ["C", [6, 7]],
         ["T", []],
         ["Q", []],
-        ["X", [0]]
+        ["X", [0]],
+        ["Z", []]
       ]      
     end
     

--- a/spec/sample_svg/close_path.svg
+++ b/spec/sample_svg/close_path.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" 
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="12cm" height="4cm" viewBox="0 0 1200 400"
+     xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <desc>Example close_path - triangle with rounded corners</desc>
+  <!-- Show outline of canvas using 'polygon' element -->
+  <path d="M 10,10 L 15,20 L 20,10 z" />
+</svg>
+


### PR DESCRIPTION
In SVG paths Z/z signifies a command to close paths. PDF has the same command for paths. More than that it's implemented in Prawn as it's very useful command.

Openness of the path has very noticeable effect. Here's an example:
![Open and closed paths example](http://cl.ly/image/300p1x2W3B0e/Screen%20Shot%202012-09-07%20at%2012.59.07%20AM.png)

The left one is open and the right one is closed.
