### PR TITLE
Add font-weight numerical range and fix installed_fonts

### DIFF
--- a/lib/prawn/svg/element.rb
+++ b/lib/prawn/svg/element.rb
@@ -139,13 +139,12 @@ class Prawn::Svg::Element
     if weight = @attributes['font-weight']
       font_updated = true
       @state[:font_weight] =  case weight
-                              when '100','200'  then :light
-                              when '300'        then :book
-                              when '400','500'  then :normal
-                              when '600'        then :semibold
-                              when '700','bold' then :bold
-                              when '800'        then :extrabold
-                              when '900'        then :black
+                              when '100','200','300' then :light
+                              when '400','500'       then :normal
+                              when '600'             then :semibold
+                              when '700','bold'      then :bold
+                              when '800'             then :extrabold
+                              when '900'             then :black
                               else nil
                               end
     end
@@ -153,14 +152,13 @@ class Prawn::Svg::Element
       font_updated = true
       @state[:font_style] = style == 'italic' ? :italic : nil
     end
-    if (family = @attributes['font-family']) && family.strip != ""
-      font_updated = true
-      @state[:font_family] = family
-    end
-    
-    if @state[:font_family] && font_updated
-      if pdf_font = Prawn::Svg::Font.map_font_family_to_pdf_font(@state[:font_family], @state[:font_weight], @state[:font_style])
-        add_call_and_enter 'font', pdf_font
+
+    font_updated = true if (family = @attributes['font-family']) && family.strip != ""
+      
+    if family && font_updated
+      if pdf_font  = Prawn::Svg::Font.map_font_family_to_pdf_font(family, @state[:font_weight], @state[:font_style])
+        @state[:font_subfamily] = Prawn::Svg::Font.font_subfamily(pdf_font,@state[:font_weight],@state[:font_style])
+        add_call_and_enter 'font', pdf_font, :style => @state[:font_subfamily]
       else
         @document.warnings << "Font family '#{@state[:font_family]}' style '#{@state[:font_style] || 'normal'}' is not a known font."
       end

--- a/lib/prawn/svg/font.rb
+++ b/lib/prawn/svg/font.rb
@@ -23,14 +23,13 @@ class Prawn::Svg::Font
   end
   
   def self.font_path(font_family, font_weight = nil, font_style = nil)
-    subfamily = font_subfamily(font_weight, font_style)
-    if installed_styles = installed_fonts[font_family.downcase]
-      installed_styles[subfamily]
+    if installed_fonts.key? font_family
+      installed_fonts[font_family][font_subfamily(font_family,font_weight, font_style)]
     end
   end
   
   def self.font_installed?(font_family, font_weight = nil, font_style = nil)
-    !font_path(font_family, font_weight, font_style).nil?
+    !font_path(font_family.downcase, font_weight, font_style).nil?
   end
 
   def self.installed_fonts
@@ -48,15 +47,24 @@ class Prawn::Svg::Font
     @installed_fonts = fonts
   end
 
-  def self.font_subfamily(font_weight = nil,font_style = nil)
-    subfamily = if font_weight == :normal and font_style
-      "#{font_style}"
-    elsif font_weight || font_style
-      "#{font_weight} #{font_style}"
-    else
-      "normal"
+  def self.font_subfamily(font_family,font_weight = nil,font_style = nil)
+    subfamily = (if font_weight == :normal and font_style
+                  "#{font_style}"
+                elsif font_weight || font_style
+                  "#{font_weight} #{font_style}"
+                else
+                  "normal"
+                end).strip().gsub(/\s+/, "_").downcase.to_sym
+
+    if installed_styles = installed_fonts[font_family.downcase]
+      if installed_styles.key? subfamily
+        subfamily
+      elsif installed_styles.key? :normal
+        :normal
+      else
+        installed_styles.values.first
+      end
     end
-    subfamily.strip().gsub(/\s+/, "_").downcase.to_sym
   end
     
   def self.font_information(filename)

--- a/lib/prawn/svg/parser/text.rb
+++ b/lib/prawn/svg/parser/text.rb
@@ -22,8 +22,8 @@ class Prawn::Svg::Parser::Text
     if size = element.state[:font_size]
       opts[:size] = size
     end
-    opts[:style] = Prawn::Svg::Font.font_subfamily(element.state[:font_weight],element.state[:font_style])
-    
+    opts[:style] = element.state[:font_subfamily]
+
     # This is not a prawn option but we can't work out how to render it here -
     # it's handled by Svg#rewrite_call_arguments
     if anchor = attrs['text-anchor']


### PR DESCRIPTION
Hi mogest,
- Add font-weight [100..900] range support.  It's not compatible with every fonts, but it's better then the actual support.  To get a better one we would need to read the 'OS/2' table from .ttf file to match the css weight with the actual font data.
- Fix the bug where setting weight + style was failing (Only italic was applied).
- Improve the installed fonts algo, now it is better at guessing  subfamily.   (It use field 16 and 17 from table 'name' of .tff file when available).  Tested with Open Sans.

Tell me what you think.  Definitely not ready to merge.  I'm working on it, if you have suggestion.
;-)
