### PR TITLE
Fix escaped HTML characters bug

### DIFF
--- a/lib/prawn/svg/parser/text.rb
+++ b/lib/prawn/svg/parser/text.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 class Prawn::Svg::Parser::Text
   def parse(element)
     element.add_call_and_enter "text_group"
@@ -34,7 +35,7 @@ class Prawn::Svg::Parser::Text
 
     element.element.children.each do |child|
       if child.node_type == :text
-        text = child.to_s.strip.gsub(/\s+/, " ")
+        text = CGI::unescape_html child.to_s.strip.gsub(/\s+/, " ")
 
         while text != "" 
           opts[:at] = [x_positions.first, y_positions.first]


### PR DESCRIPTION
With this pull request this svg excerpt : 

``` svg
<tspan>&lt;Abri.Co &amp; friends &gt;</tspan>
```

now render the correct unescaped string of text:

> <Abri.Co & friends >

instead of:

> &lt;Abri.Co &amp; friends &gt;

as Illustrator, Chrome and Safari do.
