### PR TITLE
Create namespace before requiring files.

### DIFF
--- a/lib/prawn-svg.rb
+++ b/lib/prawn-svg.rb
@@ -1,13 +1,17 @@
-require 'prawn'
-require 'prawn/svg/color'
-require 'prawn/svg/extension'
-require 'prawn/svg/interface'
-require 'prawn/svg/font'
-require 'prawn/svg/document'
-require 'prawn/svg/element'
-require 'prawn/svg/parser'
-require 'prawn/svg/parser/path'
-require 'prawn/svg/parser/text'
-require 'prawn/svg/parser/image'
+module Prawn
+  module Svg
+    require 'prawn'
+    require 'prawn/svg/color'
+    require 'prawn/svg/extension'
+    require 'prawn/svg/interface'
+    require 'prawn/svg/font'
+    require 'prawn/svg/document'
+    require 'prawn/svg/element'
+    require 'prawn/svg/parser'
+    require 'prawn/svg/parser/path'
+    require 'prawn/svg/parser/text'
+    require 'prawn/svg/parser/image'
+  end
+end
 
 Prawn::Document.extensions << Prawn::Svg::Extension


### PR DESCRIPTION
Requiring files before defining the namespace was raising the `NameError (uninitialized constant Prawn::Svg)` exception. I tried running specs before doing this PR, but they're failing:

``` text
github/prawn-svg/lib/prawn/svg/font.rb:40:in `block in load_external_fonts': undefined method `gsub' for nil:NilClass (NoMethodError)
```
