### PR TITLE
Fixes handling of "-" used to separate two coordinates.

### DIFF
--- a/lib/prawn/svg/parser/path.rb
+++ b/lib/prawn/svg/parser/path.rb
@@ -1,3 +1,4 @@
+
 module Prawn
   module Svg
     class Parser::Path
@@ -21,7 +22,7 @@ module Prawn
             cmd = c
             values = []
             value = ""
-          elsif c >= '0' && c <= '9' || c == '.' || c == "-" || c == "e" # handle scientific notation, e.g. 10e-4
+          elsif c >= '0' && c <= '9' || c == '.' || (c == "-" && value[-1] == ?e) || c == "e" # handle scientific notation, e.g. 10e-4
             unless cmd
               raise InvalidError, "Numerical value specified before character command in SVG path data"
             end
@@ -32,7 +33,7 @@ module Prawn
               value = ""
             end
           elsif c == '-'
-            values << value.to_f
+            values << value.to_f if value != ""
             value = c
           else
             raise InvalidError, "Invalid character '#{c}' in SVG path data"

--- a/spec/lib/path_spec.rb
+++ b/spec/lib/path_spec.rb
@@ -23,6 +23,17 @@ describe Prawn::Svg::Parser::Path do
       ]
     end
 
+    it "correctly parses a path where a coordinate is separated from another by a leading '-'" do
+      calls = []
+      @path.stub!(:run_path_command) {|*args| calls << args}
+      @path.parse("B4 5c31-2e-5")
+
+      calls.should == [
+        ["B", [4, 5]],
+        ["c", [31, -2e-5]],
+      ]
+    end
+
     it "correctly parses an empty path" do
       @path.should_not_receive(:run_path_command)
       @path.parse("").should == []


### PR DESCRIPTION
When "-" occurs _other_ than succeeding "e", it is not scientific notation,
but rather the leading character of the next number. E.g. "1-5"
represents the two coordinates "1" and "-5".

This fixes #30
