### PR TITLE
Corrected handling of subsequent points to 'm' relative move-to command

### DIFF
--- a/lib/prawn/svg/parser/path.rb
+++ b/lib/prawn/svg/parser/path.rb
@@ -54,7 +54,7 @@ module Prawn
           @last_point = @subpath_initial_point = [x, y]
           @calls << ["move_to", @last_point]
 
-          return run_path_command('L', values) if values.any?
+          return run_path_command(relative ? 'l' : 'L', values) if values.any?
 
         when 'Z' # closepath
           if @subpath_initial_point

--- a/spec/lib/path_spec.rb
+++ b/spec/lib/path_spec.rb
@@ -23,6 +23,20 @@ describe Prawn::Svg::Parser::Path do
       ]
     end
 
+    it "treats subsequent points to m/M command as relative/absolute depending on command" do
+
+      [
+        ["M", [1,2,3,4]],
+        ["L", [3,4]],
+        ["m", [5,6,7,8]],
+        ["l", [7,8]]
+      ].each do |args|
+        @path.should_receive(:run_path_command).with(*args).and_call_original
+      end
+
+      @path.parse("M 1,2 3,4 m 5,6 7,8")
+    end
+
     it "correctly parses an empty path" do
       @path.should_not_receive(:run_path_command)
       @path.parse("").should == []


### PR DESCRIPTION
The SVG spec requires subsequent points to 'M' to be absolute and
'm' to be relative. That is, to generate the equivalent of 'L' and
'l' respectively.

(previously both "M" and "m" with subsequent points resulted in hardcoded 'L')
