### PR TITLE
Ensure that /usr/share/fonts/truetype/ is added to the font path

### DIFF
--- a/lib/prawn/svg/interface.rb
+++ b/lib/prawn/svg/interface.rb
@@ -8,7 +8,7 @@ module Prawn
       DEFAULT_FONT_PATHS = ["/Library/Fonts", "/System/Library/Fonts", "#{ENV["HOME"]}/Library/Fonts", "/usr/share/fonts/truetype/**"]
 
       @font_path = []
-      DEFAULT_FONT_PATHS.each {|path| @font_path << path if File.exists?(path)}
+      DEFAULT_FONT_PATHS.each {|path| @font_path << path if File.exists?(File.basename(path) == "**" ? File.dirname(path) : path) }
 
       class << self; attr_accessor :font_path; end
 


### PR DESCRIPTION
The paths are checked to see if they exist, and the pattern
/usr/share/fonts/truetype/*\* would not match.

Happy for any variation of this really; a bit ugly to check for "**" like that, but it works... Now my broken file from earlier also picks up the right font on my Linux system...
