### PR TITLE
resolves #55 fall back to width & height from viewBox

### DIFF
--- a/lib/prawn/svg/calculators/document_sizing.rb
+++ b/lib/prawn/svg/calculators/document_sizing.rb
@@ -29,13 +29,14 @@ module Prawn::Svg::Calculators
 
       default_aspect_ratio = "x#{width ? "Mid" : "Min"}Y#{height ? "Mid" : "Min"} meet"
 
-      width ||= @bounds[0]
-      height ||= @bounds[1]
 
       if @view_box
         values = @view_box.strip.split(/\s+/)
         @x_offset, @y_offset, @viewport_width, @viewport_height = values.map {|value| value.to_f}
         @x_offset = -@x_offset
+
+        width ||= (@viewport_width || @bounds[0])
+        height ||= (@viewport_height || @bounds[1])
 
         @preserve_aspect_ratio ||= default_aspect_ratio
         aspect = Prawn::Svg::Calculators::AspectRatio.new(@preserve_aspect_ratio, [width, height], [@viewport_width, @viewport_height])
@@ -43,6 +44,9 @@ module Prawn::Svg::Calculators
         @y_scale = aspect.height / @viewport_height
         @x_offset -= aspect.x
         @y_offset -= aspect.y
+      else
+        width ||= @bounds[0]
+        height ||= @bounds[1]
       end
 
       @viewport_width ||= width

--- a/spec/prawn/svg/calculators/document_sizing_spec.rb
+++ b/spec/prawn/svg/calculators/document_sizing_spec.rb
@@ -70,4 +70,29 @@ describe Prawn::Svg::Calculators::DocumentSizing do
       expect(sizing.output_height).to eq 400
     end
   end
+
+  describe "#calculate when SVG does not specify width and height" do
+    let(:attributes) do
+      {"viewBox" => "0 0 100 200"}
+    end
+
+    it "calculates document sizing using width and height from viewBox" do
+      sizing.calculate
+      expect(sizing.viewport_width).to eq 100
+      expect(sizing.viewport_height).to eq 200
+      expect(sizing.output_width).to eq 100
+      expect(sizing.output_height).to eq 200
+    end
+
+    it "scales height based on value from viewBox" do
+      sizing.requested_width = 50
+      sizing.calculate
+      expect(sizing.x_scale).to eq 0.5
+      expect(sizing.y_scale).to eq 0.5
+      expect(sizing.viewport_width).to eq 100
+      expect(sizing.viewport_height).to eq 200
+      expect(sizing.output_width).to eq 50
+      expect(sizing.output_height).to eq 100
+    end
+  end
 end


### PR DESCRIPTION
If the SVG doesn't specify a width and height, use the width and height
values from the viewBox (if available) and scale as requested.