### PR TITLE
simplify whitespace split

### DIFF
--- a/lib/prawn/svg/calculators/aspect_ratio.rb
+++ b/lib/prawn/svg/calculators/aspect_ratio.rb
@@ -4,7 +4,7 @@ module Prawn::SVG::Calculators
     attr_reader :width, :height, :x, :y
 
     def initialize(value, container_dimensions, object_dimensions)
-      values = (value || "xMidYMid meet").strip.split(/\s+/)
+      values = (value || "xMidYMid meet").split(' ')
       @x = @y = 0
 
       if values.first == "defer"

--- a/lib/prawn/svg/elements/base.rb
+++ b/lib/prawn/svg/elements/base.rb
@@ -212,7 +212,7 @@ class Prawn::SVG::Elements::Base
       id_style = @document.css_parser.find_by_selector("##{source.attributes["id"]}") if source.attributes["id"]
 
       if classes = source.attributes["class"]
-        class_styles = classes.strip.split(/\s+/).collect do |class_name|
+        class_styles = classes.split(' ').collect do |class_name|
           @document.css_parser.find_by_selector(".#{class_name}")
         end
       end


### PR DESCRIPTION
when an empty string is passed to split, Ruby automatically splits on whitespace and drops empty records