### PR TITLE
Obey the fill-rule property when filling shapes

### DIFF
--- a/lib/prawn/svg/elements/base.rb
+++ b/lib/prawn/svg/elements/base.rb
@@ -163,7 +163,11 @@ class Prawn::SVG::Elements::Base
       if draw_types.empty?
         add_call_and_enter("end_path")
       else
-        add_call_and_enter(draw_types.join("_and_"))
+        options = {}
+        if computed_properties.fill_rule == 'evenodd'
+          options[:fill_rule] = :even_odd
+        end
+        add_call_and_enter(draw_types.join("_and_"), options)
       end
     end
   end

--- a/lib/prawn/svg/interface.rb
+++ b/lib/prawn/svg/interface.rb
@@ -186,7 +186,11 @@ module Prawn
           # prawn (as at 2.0.1 anyway) uses 'b' for its fill_and_stroke.  'b' is 'h' (closepath) + 'B', and we
           # never want closepath to be automatically run as it stuffs up many drawing operations, such as dashes
           # and line caps, and makes paths close that we didn't ask to be closed when fill is specified.
-          prawn.add_content 'B'
+          if properties.fill_rule == 'evenodd'
+            prawn.add_content 'B*'
+          else
+            prawn.add_content 'B'
+          end
 
         when 'noop'
           yield

--- a/lib/prawn/svg/properties.rb
+++ b/lib/prawn/svg/properties.rb
@@ -18,6 +18,7 @@ class Prawn::SVG::Properties
     "display"          => Config.new("inline", false, %w(inherit inline none), true),
     "fill"             => Config.new("black", true, %w(inherit none currentColor)),
     "fill-opacity"     => Config.new("1", true),
+    "fill-rule"        => Config.new("nonzero", true),
     "font-family"      => Config.new("sans-serif", true),
     "font-size"        => Config.new("medium", true, %w(inherit xx-small x-small small medium large x-large xx-large larger smaller)),
     "font-style"       => Config.new("normal", true, %w(inherit normal italic oblique), true),


### PR DESCRIPTION
This patch fixes issue #99, handle fill-rule="evenodd". I am not a ruby programmer so please correct my style. Also, I don't know if the inheritance rules for fill-rule is correct in the patch. Someone else should verify it against the SVG specification before merge.