### PR TITLE
Prevent from overwriting existing font-families

### DIFF
--- a/lib/prawn/svg/font_registry.rb
+++ b/lib/prawn/svg/font_registry.rb
@@ -37,8 +37,9 @@ class Prawn::SVG::FontRegistry
   def merge_external_fonts
     if @font_case_mapping.nil?
       self.class.load_external_fonts unless self.class.external_font_families
-      @font_families.merge!(self.class.external_font_families)
-
+      @font_families.merge!(self.class.external_font_families) do |key, v1, v2|
+       v1
+      end
       @font_case_mapping = @font_families.keys.each.with_object({}) do |key, result|
         result[key.downcase] = key
       end


### PR DESCRIPTION
This commit resolves an issue where the
`Prawn::SVG::FontRegistry#merge_external_fonts` method overwrites
existing values in `prawn.font_families` if those fonts are in any
of the registry paths.

This is an issue when using prawn with non roman fonts that might
not have defined subfamilies for bold, italic etc, since there aren't
necessarily equivalents in those languages (particularly with Asian
script). To make pdf's multi-lingual, users may manually
setup `prawn.font_families` to map those subfamilies to the main font.

prawn-svg overrides any custom configuration like that, resulting in a
`Prawn::Errors::UnknownFont ( is not a known font.)` exception when
prawn cannot find an appropriate font for a particular style.

This commit resolves that issue by changing the merge logic so that
if a key is already in `prawn.font_families` it is not overwritten
on merge.