### PR TITLE
Add support for Ruby 2.6

### DIFF
--- a/lib/prawn/svg/css/stylesheets.rb
+++ b/lib/prawn/svg/css/stylesheets.rb
@@ -63,7 +63,7 @@ module Prawn::SVG::CSS
     end
 
     def css_selector_to_xpath(selector)
-      selector.map do |element|
+      elements = selector.map do |element|
         pseudo_classes = Set.new(element[:pseudo_class])
 
         result = case element[:combinator]
@@ -110,7 +110,10 @@ module Prawn::SVG::CSS
         end
 
         result
-      end.join
+      end
+
+      # necessary for REXML in ruby 2.6.0
+      elements.join.sub(/\A\/\/\[/, '//*[')
     end
 
     def calculate_specificity(selector)

--- a/lib/prawn/svg/loaders/file.rb
+++ b/lib/prawn/svg/loaders/file.rb
@@ -85,7 +85,7 @@ module Prawn::SVG::Loaders
     end
 
     def assert_valid_file_uri!(uri)
-      if uri.host
+      unless uri.host.nil? || uri.host.empty?
         raise Prawn::SVG::UrlLoader::Error, "prawn-svg does not suport file: URLs with a host. Your URL probably doesn't start with three slashes, and it should."
       end
     end

--- a/spec/prawn/svg/css/stylesheets_spec.rb
+++ b/spec/prawn/svg/css/stylesheets_spec.rb
@@ -56,12 +56,22 @@ RSpec.describe Prawn::SVG::CSS::Stylesheets do
       result = Prawn::SVG::CSS::Stylesheets.new(CssParser::Parser.new, REXML::Document.new(svg)).load
       width_and_styles = result.map { |k, v| [k.attributes["width"].to_i, v] }.sort_by(&:first)
 
-      expect(width_and_styles).to eq [
+      expected = [
         [1, [["fill", "#ff0000", false]]],
         [2, [["fill", "#ff0000", false], ["fill", "#330000", false], ["fill", "#440000", false], ["fill", "#220000", false]]],
         [3, [["fill", "#ff0000", false], ["fill", "#00ff00", false]]],
         [4, [["fill", "#ff0000", false], ["fill", "#330000", false], ["fill", "#440000", false], ["fill", "#00ff00", false]]],
-        [5, [["fill", "#ff0000", false], ["fill", "#330000", false], ["fill", "#330000", false], ["fill", "#00ff00", false]]],
+      ]
+
+      # under ruby < 2.6, a bug in REXML causes the /following-sibling selector to
+      # choose one less rect than should be selected
+      if RUBY_VERSION < '2.6.0'
+        expected << [5, [["fill", "#ff0000", false], ["fill", "#330000", false], ["fill", "#330000", false], ["fill", "#00ff00", false]]]
+      else
+        expected << [5, [["fill", "#ff0000", false], ["fill", "#330000", false], ["fill", "#330000", false], ["fill", "#440000", false], ["fill", "#00ff00", false]]]
+      end
+
+      expected.concat [
         [6, [["fill", "#ff0000", false], ["fill", "#0000ff", false]]],
         [7, [["fill", "#550000", false]]],
         [8, [["fill", "#660000", false]]],
@@ -74,6 +84,8 @@ RSpec.describe Prawn::SVG::CSS::Stylesheets do
         [15, [["fill", "#dd0000", false]]],
         [16, [["fill", "#ee0000", false]]],
       ]
+
+      expect(width_and_styles).to eq(expected)
     end
   end
 


### PR DESCRIPTION
Ok, so... I'm not totally sure about this. REXML got a big bump in ruby 2.6 and I had a really hard time figuring out how to make prawn-svg compatible with both 2.6 and previous versions.

Some issues I ran into:
1. It appears REXML in 2.6 doesn't allow you to put a predicate immediately after `//`, eg `//[@foo=bar]` raises an error. Instead it annoyingly needs to be `//*[@foo=bar]`.
2. Under 2.5, it appears a bug in REXML selects one less element than it should when using `following-sibling`. I don't understand how `rect ~ rect` in CSS is equivalent to `rect/following-sibling::rect` if `rect + rect` in CSS is equivalent to `rect/following-sibling::rect[1]` (shouldn't it use `preceding-sibling`?) I would appreciate some help figuring this one out. For now I just added a conditional in the tests that account for the discrepancy between ruby versions.
3. It appears `URI("file:///foo").host` returns `""` in 2.6 and `nil` in <= 2.5 🙄

Thanks!