### PR TITLE
fix warnings

### DIFF
--- a/lib/prawn/svg/elements/path.rb
+++ b/lib/prawn/svg/elements/path.rb
@@ -16,6 +16,7 @@ class Prawn::SVG::Elements::Path < Prawn::SVG::Elements::Base
     require_attributes 'd'
 
     @commands = []
+    @last_point = nil
 
     data = attributes["d"].gsub(/#{OUTSIDE_SPACE_REGEXP}$/, '')
 

--- a/lib/prawn/svg/loaders/file.rb
+++ b/lib/prawn/svg/loaders/file.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 #
 # Load a file from disk.
 #
@@ -56,7 +58,7 @@ module Prawn::SVG::Loaders
     private
 
     def load_file(path)
-      path = URI.decode(path)
+      path = Addressable::URI.unencode(path)
       path = build_absolute_and_expand_path(path)
       assert_valid_path!(path)
       assert_file_exists!(path)


### PR DESCRIPTION
- initialize @last_point in Prawn::SVG::Elements::Path
- use Addressable::URI.unencode instead of deprecated URI.decode in Prawn::SVG::Loaders::File