### PR TITLE
Avoid unintentional string mutation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.1
+env:
+  - RUBYOPT=--enable-frozen-string-literal

--- a/lib/prawn/svg/css/selector_parser.rb
+++ b/lib/prawn/svg/css/selector_parser.rb
@@ -10,7 +10,7 @@ module Prawn::SVG::CSS
         case token
         when Modifier
           part = token.type
-          result.last[part] ||= part == :name ? "" : []
+          result.last[part] ||= part == :name ? +"" : []
         when Identifier
           return unless part
           result.last[part] << token.name
@@ -48,7 +48,7 @@ module Prawn::SVG::CSS
           case attribute
           when :pre_key
             if VALID_CSS_IDENTIFIER_CHAR.match(char)
-              result.last.key = char
+              result.last.key = String.new(char)
               attribute = :key
             elsif char != " " && char != "\t"
               return
@@ -60,7 +60,7 @@ module Prawn::SVG::CSS
             elsif char == "]"
               attribute = nil
             elsif "=*~^|$".include?(char)
-              result.last.operator = char
+              result.last.operator = String.new(char)
               attribute = :operator
             elsif char == " " || char == "\t"
               attribute = :pre_operator
@@ -70,7 +70,7 @@ module Prawn::SVG::CSS
 
           when :pre_operator
             if "=*~^|$".include?(char)
-              result.last.operator = char
+              result.last.operator = String.new(char)
               attribute = :operator
             elsif char != " " && char != "\t"
               return
@@ -82,25 +82,25 @@ module Prawn::SVG::CSS
             elsif char == " " || char == "\t"
               attribute = :pre_value
             elsif char == '"' || char == "'"
-              result.last.value = ''
-              attribute = char
+              result.last.value = +''
+              attribute = String.new(char)
             else
-              result.last.value = char
+              result.last.value = String.new(char)
               attribute = :value
             end
 
           when :pre_value
             if char == '"' || char == "'"
-              result.last.value = ''
-              attribute = char
+              result.last.value = +''
+              attribute = String.new(char)
             elsif char != " " && char != "\t"
-              result.last.value = char
+              result.last.value = String.new(char)
               attribute = :value
             end
 
           when :value
             if char == "]"
-              result.last.value = result.last.value.rstrip
+              result.last.value = String.new(result.last.value.rstrip)
               attribute = nil
             else
               result.last.value << char

--- a/lib/prawn/svg/css/stylesheets.rb
+++ b/lib/prawn/svg/css/stylesheets.rb
@@ -69,14 +69,14 @@ module Prawn::SVG::CSS
 
         result = case element[:combinator]
                  when :child
-                   "/"
+                   +"/"
                  when :adjacent
                    pseudo_classes << 'first-child'
-                   "/following-sibling::"
+                   +"/following-sibling::"
                  when :siblings
-                   "/following-sibling::"
+                   +"/following-sibling::"
                  else
-                   "//"
+                   +"//"
                  end
 
         positions = []

--- a/lib/prawn/svg/elements/base.rb
+++ b/lib/prawn/svg/elements/base.rb
@@ -237,16 +237,15 @@ class Prawn::SVG::Elements::Base
 
   def parse_css_declarations(declarations)
     # copied from css_parser
-    declarations.gsub!(/(^[\s]*)|([\s]*$)/, '')
-
-    output = {}
-    declarations.split(/[\;$]+/m).each do |decs|
-      if matches = decs.match(/\s*(.[^:]*)\s*\:\s*(.[^;]*)\s*(;|\Z)/i)
-        property, value, _ = matches.captures
-        output[property.downcase] = value
+    declarations
+      .gsub(/(^[\s]*)|([\s]*$)/, '')
+      .split(/[\;$]+/m)
+      .each_with_object({}) do |decs, output|
+        if matches = decs.match(/\s*(.[^:]*)\s*\:\s*(.[^;]*)\s*(;|\Z)/i)
+          property, value, _ = matches.captures
+          output[property.downcase] = value
+        end
       end
-    end
-    output
   end
 
   def require_attributes(*names)


### PR DESCRIPTION
Once merged, the users of this gem can safely use `RUBYOPT=--enable-frozen-string-literal` when running their app and make use of the reduced memory usage.