### PR TITLE
Add the rexml gem as a dependency for Ruby 3.0 support

### DIFF
--- a/prawn-svg.gemspec
+++ b/prawn-svg.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "prawn", ">= 0.11.1", "< 3"
   gem.add_runtime_dependency "css_parser", "~> 1.6"
+  gem.add_runtime_dependency "rexml", "~> 3.2"
   gem.add_development_dependency "rspec", "~> 3.0"
   gem.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Ruby 3.0 removed rexml from the default gems. https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/