### PR TITLE
add COLOR_MODE

### DIFF
--- a/lib/prawn/svg/color.rb
+++ b/lib/prawn/svg/color.rb
@@ -1,4 +1,6 @@
 class Prawn::SVG::Color
+  COLOR_MODE = 'rgb'.freeze
+
   RGB = Struct.new(:value)
   CMYK = Struct.new(:value)
 

--- a/lib/prawn/svg/elements/root.rb
+++ b/lib/prawn/svg/elements/root.rb
@@ -9,7 +9,7 @@ class Prawn::SVG::Elements::Root < Prawn::SVG::Elements::Base
 
   def apply
     if [nil, 'inherit', 'none', 'currentColor'].include?(properties.fill)
-      add_call 'fill_color', '000000'
+      add_call 'fill_color', Prawn::SVG::Color::COLOR_MODE == 'rgb' ? '000000' : [0, 0, 0, 100]
     end
 
     add_call 'transformation_matrix', @document.sizing.x_scale, 0, 0, @document.sizing.y_scale, 0, 0


### PR DESCRIPTION
I added a COLOR_MODE constant to be able to set the black color using RGB or CMYK values.

In an initializer we could add something like this in order to have all default colors in CMYK:

```
Prawn::SVG::Color::COLOR_MODE = 'cmyk'.freeze
Prawn::SVG::Color::DEFAULT_COLOR = Prawn::SVG::Color::CMYK.new([0, 0, 0, 100])
```

This PR refers to the issue #140 