### PR TITLE
Support middle function of dominant-baseline for <text>

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ prawn-svg supports most but not all of the full SVG 1.1 specification.  It curre
    implementation of elliptical arc is a bit rough at the moment.
 
  - `<text>`, `<tspan>` and `<tref>` with attributes `x`, `y`, `dx`, `dy`, `rotate`, 'textLength', 'lengthAdjust', and with extra properties
-   `text-anchor`, `text-decoration` (underline only), `font-size`, `font-family`, `font-weight`, `font-style`, `letter-spacing`
+   `text-anchor`, `text-decoration` (underline only), `font-size`, `font-family`, `font-weight`, `font-style`, `letter-spacing`, `dominant-baseline` (middle only)
 
  - <tt>&lt;svg&gt;</tt>, <tt>&lt;g&gt;</tt> and <tt>&lt;symbol&gt;</tt>
 

--- a/lib/prawn/svg/elements/text_component.rb
+++ b/lib/prawn/svg/elements/text_component.rb
@@ -47,9 +47,9 @@ class Prawn::SVG::Elements::TextComponent < Prawn::SVG::Elements::DepthFirstBase
       size:        computed_properties.numerical_font_size,
       style:       font && font.subfamily,
       text_anchor: computed_properties.text_anchor,
-      dominant_baseline: computed_properties.dominant_baseline,
     }
 
+    opts[:dominant_baseline] = computed_properties.dominant_baseline unless computed_properties.dominant_baseline == 'auto'
     opts[:decoration] = computed_properties.text_decoration unless computed_properties.text_decoration == 'none'
 
     if state.text.parent

--- a/lib/prawn/svg/elements/text_component.rb
+++ b/lib/prawn/svg/elements/text_component.rb
@@ -41,12 +41,13 @@ class Prawn::SVG::Elements::TextComponent < Prawn::SVG::Elements::DepthFirstBase
     font = select_font
     apply_font(font) if font
 
-    # text_anchor isn't a Prawn option; we have to do some math to support it
-    # and so we handle this in Prawn::SVG::Interface#rewrite_call_arguments
+    # text_anchor and dominant_baseline aren't Prawn options; we have to do some math to support them
+    # and so we handle them in Prawn::SVG::Interface#rewrite_call_arguments
     opts = {
       size:        computed_properties.numerical_font_size,
       style:       font && font.subfamily,
       text_anchor: computed_properties.text_anchor,
+      dominant_baseline: computed_properties.dominant_baseline,
     }
 
     opts[:decoration] = computed_properties.text_decoration unless computed_properties.text_decoration == 'none'

--- a/lib/prawn/svg/interface.rb
+++ b/lib/prawn/svg/interface.rb
@@ -149,6 +149,13 @@ module Prawn
           at[0] = @cursor[0] if at[0] == :relative
           at[1] = @cursor[1] if at[1] == :relative
 
+          case options.delete(:dominant_baseline)
+          when 'middle'
+            height = prawn.font.height
+            at[1] -= height / 2.0
+            @cursor = [at[0], at[1]]
+          end
+
           if offset = options.delete(:offset)
             at[0] += offset[0]
             at[1] -= offset[1]

--- a/lib/prawn/svg/properties.rb
+++ b/lib/prawn/svg/properties.rb
@@ -38,6 +38,7 @@ class Prawn::SVG::Properties
     "stroke-width"     => Config.new("1", true),
     "text-anchor"      => Config.new("start", true, %w(inherit start middle end), true),
     'text-decoration'  => Config.new('none', true, %w(inherit none underline), true),
+    "dominant-baseline" => Config.new("auto", true, %w(inherit auto middle), true),
   }.freeze
 
   PROPERTIES.each do |name, value|


### PR DESCRIPTION
This PR adds supports "middle" value of [`dominant-baseline`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline).
 
Following is the example SVG:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<svg height='82' preserveAspectRatio='xMidYMid meet' xmlns:svg='http://www.w3.org/2000/svg' version='1.0' viewBox='0 0 841 82' width='841' xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg'>

  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='start' x='44' y='22'>31</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='end' x='196' y='22'>24</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='start' x='204' y='22'>23</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='end' x='356' y='22'>16</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='start' x='364' y='22'>15</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='end' x='516' y='22'>8</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='start' x='524' y='22'>7</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='end' x='676' y='22'>0</text>

  <line stroke='#000000' stroke-width='1' x1='40' x2='200' y1='41' y2='41'/>
  <line stroke='#000000' stroke-width='1' x1='40' x2='200' y1='81' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='200' x2='200' y1='41' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='40' x2='40' y1='41' y2='81'/>

  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='middle' x='120' y='62'>field3</text>

  <line stroke='#000000' stroke-width='1' x1='200' x2='360' y1='41' y2='41'/>
  <line stroke='#000000' stroke-width='1' x1='200' x2='360' y1='81' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='360' x2='360' y1='41' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='200' x2='200' y1='41' y2='81'/>

  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='middle' x='280' y='62'>field2</text>

  <line stroke='#000000' stroke-width='1' x1='360' x2='520' y1='41' y2='41'/>
  <line stroke='#000000' stroke-width='1' x1='360' x2='520' y1='81' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='520' x2='520' y1='41' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='360' x2='360' y1='41' y2='81'/>

  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='middle' x='440' y='62'>field1</text>

  <line stroke='#000000' stroke-width='1' x1='520' x2='680' y1='41' y2='41'/>
  <line stroke='#000000' stroke-width='1' x1='520' x2='680' y1='81' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='680' x2='680' y1='41' y2='81'/>
  <line stroke='#000000' stroke-width='1' x1='520' x2='520' y1='41' y2='81'/>

  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='middle' x='600' y='62'>field0</text>
  <text dominant-baseline='middle' font-family='M+ 1p Fallback' font-size='20' text-anchor='middle' x='760' y='62'>register0</text>

</svg>
```
This is the render figure before the change (texts are not in the middle of the box):
<img width="1065" alt="before" src="https://github.com/mogest/prawn-svg/assets/22725367/4021fba1-63c1-4012-8062-680f5431c180">

This is the render figure after the change (texts are in the middle of the box):
<img width="1075" alt="after" src="https://github.com/mogest/prawn-svg/assets/22725367/655dc3fc-1fa4-4648-ac67-8dabef38d288">
