### PR TITLE
don't explode if gradient has no name (Closes #162)

### DIFF
--- a/lib/prawn/svg/gradients.rb
+++ b/lib/prawn/svg/gradients.rb
@@ -36,6 +36,7 @@ module Prawn::SVG
     end
 
     def gradient_element?(raw_element)
+      return false if raw_element.nil? || raw_element.name.nil?
       Elements::TAG_CLASS_MAPPING[raw_element.name.to_sym] == Elements::Gradient
     end
 


### PR DESCRIPTION
return false on gradient_element? check if the raw_element.name is nil, i.e. element has no name
