### PR TITLE
Extend rexml version from ~> 3.2 to >= 3.2, < 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       css_parser (~> 1.6)
       matrix (~> 0.4.2)
       prawn (>= 0.11.1, < 3)
-      rexml (~> 3.2)
+      rexml (>= 3.2.0, < 4)
 
 GEM
   remote: http://rubygems.org/

--- a/prawn-svg.gemspec
+++ b/prawn-svg.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'css_parser', '~> 1.6'
   gem.add_runtime_dependency 'matrix', '~> 0.4.2'
   gem.add_runtime_dependency 'prawn', '>= 0.11.1', '< 3'
-  gem.add_runtime_dependency 'rexml', '~> 3.2'
+  gem.add_runtime_dependency 'rexml', '>=3.2.0', '< 4'
 end


### PR DESCRIPTION
This allows rexml to be updated by client apps to solve https://www.ruby-lang.org/en/news/2024/07/16/dos-rexml-cve-2024-39908/