### PR TITLE
Support REXML 3.3.3 invalid XML handling

### DIFF
--- a/lib/prawn/svg/document.rb
+++ b/lib/prawn/svg/document.rb
@@ -17,7 +17,11 @@ class Prawn::SVG::Document
     :color_mode
 
   def initialize(data, bounds, options, font_registry: nil, css_parser: CssParser::Parser.new, attribute_overrides: {})
-    @root = REXML::Document.new(data).root
+    begin
+      @root = REXML::Document.new(data).root
+    rescue REXML::ParseException
+      @root = nil
+    end
 
     if @root.nil?
       if data.respond_to?(:end_with?) && data.end_with?('.svg')


### PR DESCRIPTION
With https://github.com/ruby/rexml/commit/2bca7bd84a5cf13af8f5633dd7d3d519fc990d67 REXML now detects invalid XML with unsupported content before root element and raises REXML::ParseException rather than returning empty root.

Support this REXML exception in Prawn::SVG::Document initializer.