### PR TITLE
Fix bug when gradient used on element without bounding box

### DIFF
--- a/lib/prawn/svg/elements/gradient.rb
+++ b/lib/prawn/svg/elements/gradient.rb
@@ -35,7 +35,7 @@ class Prawn::SVG::Elements::Gradient < Prawn::SVG::Elements::Base
         to:           [cx, cy],
         r2:           r,
         stops:        stops,
-        matrix:       matrix_for_bounding_box(*bbox),
+        matrix:       matrix_for_bounding_box(bbox),
         wrap:         wrap,
         bounding_box: bbox
       }
@@ -44,7 +44,7 @@ class Prawn::SVG::Elements::Gradient < Prawn::SVG::Elements::Base
         from:         [x1, y1],
         to:           [x2, y2],
         stops:        stops,
-        matrix:       matrix_for_bounding_box(*bbox),
+        matrix:       matrix_for_bounding_box(bbox),
         wrap:         wrap,
         bounding_box: bbox
       }
@@ -57,8 +57,10 @@ class Prawn::SVG::Elements::Gradient < Prawn::SVG::Elements::Base
 
   private
 
-  def matrix_for_bounding_box(bounding_x1, bounding_y1, bounding_x2, bounding_y2)
-    if units == :bounding_box
+  def matrix_for_bounding_box(bbox)
+    if bbox && units == :bounding_box
+      bounding_x1, bounding_y1, bounding_x2, bounding_y2 = *bbox
+
       width = bounding_x2 - bounding_x1
       height = bounding_y1 - bounding_y2
 

--- a/spec/prawn/svg/elements/gradient_spec.rb
+++ b/spec/prawn/svg/elements/gradient_spec.rb
@@ -24,6 +24,24 @@ describe Prawn::SVG::Elements::Gradient do
       expect(document.gradients['flag']).to eq element
     end
 
+    it 'returns correct gradient arguments for an element with no bounding box' do
+      arguments = element.gradient_arguments(double(bounding_box: nil))
+      expect(arguments).to eq(
+        from:         [0.0, 0.0],
+        to:           [0.2, 1.0],
+        wrap:         :pad,
+        matrix:       Matrix[[1.0, 0.0, 0.0], [0.0, -1.0, 600.0], [0.0, 0.0, 1.0]],
+        bounding_box: nil,
+        stops:        [
+          { offset: 0, color: 'ff0000', opacity: 1.0 },
+          { offset: 0.25, color: 'ff0000', opacity: 1.0 },
+          { offset: 0.5, color: 'ffffff', opacity: 1.0 },
+          { offset: 0.75, color: '0000ff', opacity: 1.0 },
+          { offset: 1, color: '0000ff', opacity: 1.0 }
+        ]
+      )
+    end
+
     it 'returns correct gradient arguments for an element' do
       arguments = element.gradient_arguments(double(bounding_box: [100, 100, 200, 0]))
       expect(arguments).to eq(


### PR DESCRIPTION
This is a regression, which used to be handled correctly but was broken in 4da7475ee03e2df6de95c697ad8e9cbd88dfa2a7. Some elements (eg. text) don't return a valid bounding box, so they can't currently be used with `gradientUnits` set to `userSpaceOnUse`.

Because we were passing `matrix_for_bounding_box(nil)` this was causing an exception.