### PR TITLE
Support links via anchor ("a") elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Pseudo-elements and the other pseudo-classes are not supported.
 
 ## Not supported
 
-prawn-svg does not support hyperlinks, patterns, masks or filters.
+prawn-svg does not support patterns, masks or filters.
 
 It does not support text in the clip area, but you can clip shapes and text by any shape.
 

--- a/lib/prawn-svg.rb
+++ b/lib/prawn-svg.rb
@@ -38,6 +38,7 @@ require 'prawn/svg/ttf'
 require 'prawn/svg/font'
 require 'prawn/svg/gradients'
 require 'prawn/svg/gradient_renderer'
+require 'prawn/svg/link_renderer'
 require 'prawn/svg/document'
 require 'prawn/svg/state'
 

--- a/lib/prawn/svg/elements.rb
+++ b/lib/prawn/svg/elements.rb
@@ -4,7 +4,7 @@ end
 
 require 'prawn/svg/elements/call_duplicator'
 
-%w[base direct_render_base root container clip_path viewport text text_component text_node line polyline polygon circle ellipse
+%w[base direct_render_base root anchor container clip_path viewport text text_component text_node line polyline polygon circle ellipse
    rect path use image gradient marker ignored].each do |filename|
   require "prawn/svg/elements/#{filename}"
 end
@@ -14,7 +14,7 @@ module Prawn::SVG::Elements
     g:              Prawn::SVG::Elements::Container,
     symbol:         Prawn::SVG::Elements::Container,
     defs:           Prawn::SVG::Elements::Container,
-    a:              Prawn::SVG::Elements::Container,
+    a:              Prawn::SVG::Elements::Anchor,
     clipPath:       Prawn::SVG::Elements::ClipPath,
     switch:         Prawn::SVG::Elements::Container,
     svg:            Prawn::SVG::Elements::Viewport,

--- a/lib/prawn/svg/elements/anchor.rb
+++ b/lib/prawn/svg/elements/anchor.rb
@@ -1,0 +1,9 @@
+class Prawn::SVG::Elements::Anchor < Prawn::SVG::Elements::Base
+  def parse
+    state.anchor_href = href_attribute
+  end
+
+  def container?
+    true
+  end
+end

--- a/lib/prawn/svg/elements/base.rb
+++ b/lib/prawn/svg/elements/base.rb
@@ -56,6 +56,10 @@ class Prawn::SVG::Elements::Base
     apply_calls_from_standard_attributes
     apply
 
+    if state.anchor_href && bounding_box
+      add_call('svg:add_link', state.anchor_href, bounding_box)
+    end
+
     process_child_elements if container?
 
     append_calls_to_parent unless computed_properties.display == 'none'

--- a/lib/prawn/svg/elements/text_node.rb
+++ b/lib/prawn/svg/elements/text_node.rb
@@ -110,7 +110,10 @@ module Prawn::SVG
         cursor.y = chunk.y if chunk.y
         cursor.y -= chunk.dy if chunk.dy
 
-        render_underline(prawn, size, cursor, y_offset, chunk.fixed_width || chunk.base_width) if component.computed_properties.text_decoration == 'underline'
+        width = chunk.fixed_width || chunk.base_width
+
+        render_underline(prawn, size, cursor, y_offset, width) if component.computed_properties.text_decoration == 'underline'
+        render_link_annotation(prawn, size, cursor, y_offset, width)
 
         opts = { size: size, at: [cursor.x, cursor.y + (y_offset || 0)] }
         opts[:rotate] = chunk.rotate if chunk.rotate
@@ -154,6 +157,20 @@ module Prawn::SVG
       offset, thickness = FontMetrics.underline_metrics(prawn, size)
 
       prawn.fill_rectangle [cursor.x, cursor.y + (y_offset || 0) + offset + (thickness / 2.0)], width, thickness
+    end
+
+    def render_link_annotation(prawn, size, cursor, y_offset, width)
+      href = component.state.anchor_href
+      return unless href
+
+      text_bottom = cursor.y + (y_offset || 0) - scaled_font_size(prawn, :descender, size)
+      font_height = scaled_font_size(prawn, :height, size)
+
+      LinkRenderer.new(href, [cursor.x, text_bottom + font_height, cursor.x + width, text_bottom]).render(prawn)
+    end
+
+    def scaled_font_size(prawn, method_name, size)
+      (prawn.font.public_send(method_name) / prawn.font_size) * size
     end
 
     def calculate_text_rendering_mode

--- a/lib/prawn/svg/link_renderer.rb
+++ b/lib/prawn/svg/link_renderer.rb
@@ -1,0 +1,40 @@
+class Prawn::SVG::LinkRenderer
+  include Prawn::SVG::PDFMatrix
+
+  def initialize(href, bounding_box)
+    @href = href
+    @bounding_box = bounding_box
+  end
+
+  def render(prawn)
+    prawn.link_annotation(transformed_bounding_box(prawn), {
+      Border: [0, 0, 0],
+      A:      { Type: :Action, S: :URI, URI: PDF::Core::LiteralString.new(href) }
+    })
+  end
+
+  private
+
+  attr_reader :href, :bounding_box
+
+  def transformed_bounding_box(prawn)
+    x0, y0, x1, y1 = bounding_box
+
+    matrix = load_matrix(prawn.current_transformation_matrix_with_translation(*prawn.bounds.anchor))
+
+    corners = [
+      matrix * Vector[x0, y0, 1.0],
+      matrix * Vector[x0, y1, 1.0],
+      matrix * Vector[x1, y0, 1.0],
+      matrix * Vector[x1, y1, 1.0]
+    ]
+
+    xs = corners.map { |c| c[0] }
+    ys = corners.map { |c| c[1] }
+
+    tx0, tx1 = xs.minmax
+    ty0, ty1 = ys.minmax
+
+    [tx0, ty0, tx1, ty1]
+  end
+end

--- a/lib/prawn/svg/renderer.rb
+++ b/lib/prawn/svg/renderer.rb
@@ -183,6 +183,10 @@ module Prawn
           type = arguments.first
           GradientRenderer.new(prawn, type, **kwarguments).draw
           yield
+
+        when 'svg:add_link'
+          LinkRenderer.new(*arguments).render(prawn)
+          yield
         end
       end
 

--- a/lib/prawn/svg/state.rb
+++ b/lib/prawn/svg/state.rb
@@ -4,7 +4,7 @@ class Prawn::SVG::State
     :stroke_width,
     :computed_properties,
     :viewport_sizing,
-    :inside_use, :inside_clip_path
+    :inside_use, :inside_clip_path, :anchor_href
 
   def initialize
     @stroke_width = 1

--- a/spec/sample_svg/links.svg
+++ b/spec/sample_svg/links.svg
@@ -1,10 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="1200" height="400" viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+<svg viewBox="0 0 350 250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <text fill="#000000" font-family="sans-serif" font-size="13" textLength="78" x="14" y="20">You can use</text>
   <a target="_top" xlink:actuate="onRequest" xlink:href="http://plantuml.com/start" xlink:show="new" xlink:title="http://plantuml.com/start" xlink:type="simple">
     <text fill="#0000FF" font-family="sans-serif" font-size="13" text-decoration="underline" textLength="87" x="96" y="20">links in notes</text>
-    <line style="stroke: #0000FF; stroke-width: 1.0;" x1="96" x2="183" y1="20" y2="20"/>
   </a>
 
   <g transform="translate(0 20)">
@@ -12,6 +11,47 @@
     <a target="_top" xlink:actuate="onRequest" xlink:href="http://plantuml.com/start" xlink:show="new" xlink:title="http://plantuml.com/start" xlink:type="simple">
       <text fill="#0000FF" font-family="sans-serif" font-size="13" text-decoration="underline" textLength="87" lengthAdjust="spacingAndGlyphs" x="96" y="20">links in notes</text>
       <line style="stroke: #0000FF; stroke-width: 1.0;" x1="96" x2="183" y1="20" y2="20"/>
+    </a>
+  </g>
+
+  <!-- A link around a circle and text -->
+  <a href="https://example.com/circle">
+    <circle fill="lightcoral" cx="50" cy="90" r="35" />
+    <text x="50" y="145" text-anchor="middle">circle</text>
+  </a>
+
+  <!-- A link around a rotated square, bounding box should fit nicely -->
+  <a href="https://example.com/square">
+    <rect fill="lightcoral" x="100" y="65" width="50" height="50" transform="translate(125 90) rotate(45) translate(-125 -90)" />
+  </a>
+
+  <!-- A link inside a translated group -->
+  <g transform="translate(170 65)">
+    <a href="https://example.com/square-in-group">
+      <rect fill="lightcoral" x="0" y="0" width="50" height="50" />
+    </a>
+  </g>
+
+  <!-- A link inside a rotated group -->
+  <g transform="translate(270 90) rotate(30) translate(-25 -25)">
+    <a href="https://example.com/square-in-rotated-group">
+      <rect fill="lightcoral" x="0" y="0" width="50" height="50" />
+    </a>
+  </g>
+
+  <!-- A link inside a text element -->
+  <!-- NOTE: I believe this is valid, but is not yet supported -->
+<!--   <g transform="translate(250 20)">
+    <text x="0" y="0" font-size="13">
+      <a href="https://example.com" target="_blank">Link inside text</a>
+    </text>
+  </g>
+ -->
+
+  <!-- Longer text -->
+  <g transform="translate(20 170)">
+    <a href="https://example.com/longer-text">
+      <text x="0" y="0" font-size="13">Some longer <tspan>sub-divided</tspan> text</text>
     </a>
   </g>
 </svg>


### PR DESCRIPTION
Add links using Prawn's `link_annotation`. This works with any element that defines a bounding box, and also text. We transform the bounding box into PDF page space and then fit the link area as tightly as we can around the resulting box. This means the link area will tightly fit a rotated rectangle, for example.

One thing that isn't supported is adding links inside a text element. If you have the following markup:

```svg
<text>Text with a <a href="...">link</a> inside.</text>
```

I believe this is a valid SVG, but the current parser in prawn-svg doesn't handle this nesting, so it is beyond the scope of this PR.