### PR TITLE
Fix font metrics caching

### DIFF
--- a/spec/prawn/svg/font_metrics_spec.rb
+++ b/spec/prawn/svg/font_metrics_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Prawn::SVG::FontMetrics do
+  let(:pdf) { Prawn::Document.new }
+
+  describe '.underline_metrics' do
+    it 'does not return the same values for different font sizes' do
+      underline_10 = described_class.underline_metrics(pdf, 10)
+      underline_20 = described_class.underline_metrics(pdf, 20)
+
+      expect(underline_10).to_not eq(underline_20)
+    end
+  end
+end


### PR DESCRIPTION
Make sure that `underline_metrics` includes the `size` in the cache key.

This is a small error in caching that I noticed while working on https://github.com/mogest/prawn-svg/pull/190. I didn't end up modifying `font_metrics.rb` as part of that PR, so I thought I would open this one separately.