### PR TITLE
Allow css_parser 3.x (closes SSRF/file-disclosure via GHSA-9pmc-p236-855h)

### DIFF
--- a/prawn-svg.gemspec
+++ b/prawn-svg.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_dependency 'css_parser', '>= 1.6', '< 3'
+  gem.add_dependency 'css_parser', '>= 1.6', '< 4'
   gem.add_dependency 'matrix', '~> 0.4.2'
   gem.add_dependency 'prawn', '>= 0.11.1', '< 3'
   gem.add_dependency 'rexml', '>= 3.4.2', '< 4'


### PR DESCRIPTION
## Summary

css_parser 3.0.0 ships the fix for [GHSA-9pmc-p236-855h](https://github.com/premailer/css_parser/security/advisories/GHSA-9pmc-p236-855h) / CVE-2026-53727 (SSRF and local file disclosure in `CssParser::Parser#read_remote_file`). The current gemspec upper-bound `'< 3'` https://github.com/mogest/prawn-svg/issues/198

This is the same one-line relaxation pattern as #195 (1.x → 2.x), bumping the upper bound one major higher.

## Why this is safe

the 3.0.0 release only changes one library file (`lib/css_parser/parser.rb`). The css_parser APIs prawn-svg uses are unchanged:

- `CssParser::Parser.new` constructor signature is unchanged; 3.0 only adds two new default-`false` opt-in keys (`allow_local_network`, `allow_file_uris`).
- `CssParser::CircularReferenceError` still exists (rescued in `lib/prawn/svg/css/stylesheets.rb`).
- `add_block!` and `each_rule_set` are byte-identical to 2.2.0.

The new strict defaults in 3.x (refusing `file://` URIs and loopback / private-IP HTTP fetches via `ssrf_filter`) are exactly what prawn-svg consumers want when no custom `UrlLoader` is configured — without this bump, an SVG containing `<style>@import url('http://internal/...')</style>` could be used to SSRF the host process via the embedded css_parser.

## Test plan

- [x] `bundle install` resolves css_parser 3.0.0 + ssrf_filter 1.5.0 (Ruby 3.3.9)
- [x] `bundle exec rspec` → **717 examples, 0 failures**
- [x] All `spec/prawn/svg/css/stylesheets_spec.rb` `@import` cases pass: url_loader override, nested `@import`, circular `@import`, failed-`@import` warning, and the no-url_loader path
- [ ] CI matrix on this PR

## Ruby version note

css_parser 2.0+ already requires Ruby ≥ 3.2; prawn-svg's `required_ruby_version` stays at `>= 2.7.0`. Bundler will continue to resolve css_parser 1.x for consumers on older Rubies.

Refs #195, #197.